### PR TITLE
Get container ids from directory the control script is located in

### DIFF
--- a/control
+++ b/control
@@ -1,9 +1,13 @@
 #! /bin/bash
 
-## Site specific configuration - container names. Set in .yml file. 
-webcont=moodle
-dbcont=moodledb
-dbtestcont=moodletestdb
+## Change to directory of where this script is located
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $DIR;
+
+## Site specific configuration - container id's for containers in this directory
+webcont="$(docker-compose ps -q moodle)"
+dbcont="$(docker-compose ps -q moodle-db)"
+dbtestcont="$(docker-compose ps -q moodle-test-db)"
 
 for ARG in $*
     do

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,12 @@ version: '3'
 
 services:
   moodle:
-    container_name: moodle
     build: ./moodle
     ports:
       - "80:80"
     volumes:
       - ./siteroot:/siteroot
   moodle-db:
-    container_name: moodledb
     image: postgres
     restart: always
     environment:
@@ -19,7 +17,6 @@ services:
     volumes: 
       - 'moodledb:/var/lib/postgresql'
   moodle-test-db:
-    container_name: moodletestdb
     image: postgres
     restart: always
     environment:


### PR DESCRIPTION
  - Don't use container names in .yml file because they must be unique

@kenneth-hendricks  I think this change does what we want