### PR TITLE
Make Moodle web interface only expose to localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   moodle:
     build: ./docker/moodle
     ports:
-      - "80:80"
+      - "127.0.0.1:80:80"
     volumes:
       - ./siteroot:/siteroot
   db:


### PR DESCRIPTION
The Docker containers should not expose themselves beyond the local machine.
For this purpose, any exposed port should bind to the lo interface (127.0.0.1), as otherwise docker will bind it to all interfaces.

KC: ideally this should be applied to all branches, but also the two pgsql instances should only be accessible within the docker compose network, not outside. thanks!