### PR TITLE
Fix - ERROR 2006 (HY000) at line 1349: MySQL server has gone away

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       MYSQL_DATABASE: moodle
       MYSQL_USER: moodle_user
       MYSQL_PASSWORD: password
-    command: mysqld --innodb-file-format=Barracuda --innodb_file_per_table=1 --innodb_large_prefix=1
+    command: mysqld --innodb-file-format=Barracuda --innodb_file_per_table=1 --innodb_large_prefix=1 --max_allowed_packet=32M --innodb_log_file_size=512M --explicit_defaults_for_timestamp=1
     volumes:
       - 'db:/var/lib/mysql'
   test-db:
@@ -26,7 +26,7 @@ services:
       MYSQL_DATABASE: moodle
       MYSQL_USER: moodle_user
       MYSQL_PASSWORD: password
-    command: mysqld --innodb-file-format=Barracuda --innodb_file_per_table=1 --innodb_large_prefix=1 
+    command: mysqld --innodb-file-format=Barracuda --innodb_file_per_table=1 --innodb_large_prefix=1 --max_allowed_packet=32M --innodb_log_file_size=512M --explicit_defaults_for_timestamp=1
     volumes:
       - 'testdb:/var/lib/mysql'
 volumes:


### PR DESCRIPTION
Hi @kenneth-hendricks, Since last few times I am facing 'ERROR 2006 (HY000) at line 1349: MySQL server has gone away' error while importing mysql database. This fix has been fixing error. Please review and if you think its ok to include, please merge. Thank you.